### PR TITLE
IS-2 migrate sugarfunge api docker to aws

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: DockerMultiplatformAWS
 on:
   push:
-    branches: [ IS-2-migrate-sugarfunge-api-docker-to-aws ]
+    branches: [ main ]
 jobs:
     build-arm64:
         runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,82 +1,55 @@
-name: DockerMultiplatform
+name: DockerMultiplatformAWS
 on:
   push:
-    branches: [ main ]
+    branches: [ IS-2-migrate-sugarfunge-api-docker-to-aws ]
 jobs:
     build-arm64:
-        runs-on: [self-hosted, linux, ARM64]
+        runs-on: [ self-hosted, linux, ARM64 ]
         steps:
-        - name: 'Checkout GitHub Action'
+        - name: 'Checkout Github Action'
           uses: actions/checkout@main
-        - name: 'Login to ACR'
-          uses: azure/docker-login@v1
+
+        - name: Configure AWS credentials
+          uses: aws-actions/configure-aws-credentials@v1
           with:
-            login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-            username: ${{ secrets.REGISTRY_USERNAME }}
-            password: ${{ secrets.REGISTRY_PASSWORD }}
-        - name: 'Build and Push ARM64 image' 
+            aws-region: ${{ secrets.AWS_REGION }}
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+        - name: Login to Amazon ECR
+          id: login-ecr
+          uses: aws-actions/amazon-ecr-login@v1
+
+        - name: Build, tag, and push docker image to Amazon ECR
+          env:
+            REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+            REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
+            IMAGE_TAG: arm64-${{ github.sha }}
           run: |
-            docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/api:arm64-latest -f docker/Dockerfile .
-            docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/api:arm64-latest
+            docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG . -f docker/Dockerfile
+            docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
     build-amd64:
         runs-on: ubuntu-latest
         steps:
-        - name: 'Checkout GitHub Action'
+        - name: 'Checkout Github Action'
           uses: actions/checkout@main
-        - name: 'Login to ACR'
-          uses: azure/docker-login@v1
+
+        - name: Configure AWS credentials
+          uses: aws-actions/configure-aws-credentials@v1
           with:
-            login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-            username: ${{ secrets.REGISTRY_USERNAME }}
-            password: ${{ secrets.REGISTRY_PASSWORD }}
-        - name: 'Build and Push AMD64 image'
+            aws-region: ${{ secrets.AWS_REGION }}
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+        - name: Login to Amazon ECR
+          id: login-ecr
+          uses: aws-actions/amazon-ecr-login@v1
+
+        - name: Build, tag, and push docker image to Amazon ECR
+          env:
+            REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+            REPOSITORY: ${{ secrets.AWS_ECR_REPOSITORY }}
+            IMAGE_TAG: amd64-${{ github.sha }}
           run: |
-            docker build -t ${{ secrets.REGISTRY_LOGIN_SERVER }}/api:amd64-latest -f docker/Dockerfile .
-            docker push ${{ secrets.REGISTRY_LOGIN_SERVER }}/api:amd64-latest
-    manifest-notify:
-        needs: [build-arm64, build-amd64]
-        runs-on: ubuntu-latest
-        steps:
-          - name: 'Login to ACR'
-            uses: azure/docker-login@v1
-            with:
-              login-server: ${{ secrets.REGISTRY_LOGIN_SERVER }}
-              username: ${{ secrets.REGISTRY_USERNAME }}
-              password: ${{ secrets.REGISTRY_PASSWORD }}
-          - name: 'Create and Push manifest'
-            run: |
-              docker manifest create ${{ secrets.REGISTRY_LOGIN_SERVER }}/api:latest \
-              --amend ${{ secrets.REGISTRY_LOGIN_SERVER }}/api:amd64-latest \
-              --amend ${{ secrets.REGISTRY_LOGIN_SERVER }}/api:arm64-latest
-          - uses: slackapi/slack-github-action@v1.18.0
-            with:
-              channel-id: ${{ secrets.SUGARFUNGE_SLACK_CHANNEL_ID }}
-              payload: |
-                {
-                  "text": "sugarfunge-api Image Updated",
-                  "blocks": [
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "<https://github.com/SugarFunge/sugarfunge-api | sugarfunge-api> Image Updated :white_check_mark:\n Remember to run `docker-compose pull` to update the image if you're using the `latest` tag!"
-                      }
-                    },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*Commit:* <${{ github.event.pull_request.html_url || github.event.head_commit.url }} | ${{ github.sha }}>"
-                      }
-                    },
-                    {
-                      "type": "section",
-                      "text": {
-                        "type": "mrkdwn",
-                        "text": "*Author:* ${{ github.event.pusher.name }}"
-                      }
-                    }
-                  ]
-                }
-            env:
-              SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+            docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG . -f docker/Dockerfile
+            docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,13 @@ on:
     branches: [ IS-2-migrate-sugarfunge-api-docker-to-aws ]
 jobs:
     build-arm64:
-        runs-on: [ self-hosted, linux, ARM64 ]
+        runs-on: ubuntu-latest
         steps:
+        - name: Setup QEMU
+          uses: docker/setup-qemu-action@v2
+          with:
+            platforms: arm64
+
         - name: 'Checkout Github Action'
           uses: actions/checkout@main
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /scratch.txt
+.secrets


### PR DESCRIPTION
### Changes

- Update github action to build and push the sugarfunge-api image to aws instead of azure
- Secrets configuration
- Configure action to build to both amd64 and arm64 platforms using qemu

### Possible Improvements

- Update action to use aws role based authentications instead of access key / secret
- Publish messages to slack

### Jira Ticket

- <https://sortium.atlassian.net/browse/IS-2>
